### PR TITLE
Fix over-100% width

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,6 +5,8 @@ body {
   background-color: #343541;
 }
 
+* { box-sizing: border-box; }
+
 @supports (-webkit-touch-callout: none) {
 
   #chatcontainer,


### PR DESCRIPTION
The header's width is supposed to be 100%, but the padding makes it go over the screen's right edge - because `content-box` is the default value for `box-sizing`.
Adding a CSS selector for setting the [`box-sizing` to `border-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) to fix this issue.